### PR TITLE
Update ssh command to resolve error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,4 @@ ssh-keyscan $1 >> /root/.ssh/known_hosts
 
 ssh -o StrictHostKeyChecking=no $3@$1
 
-ssh -i /root/.ssh/key.pem $3@$1 -p $2 "$5"
+ssh -tt -i /root/.ssh/key.pem $3@$1 -p $2 "$5"


### PR DESCRIPTION
Error: Pseudo-terminal will not be allocated because stdin is not a terminal.